### PR TITLE
Added defn-, deftest, deftest- to oneIndentForms

### DIFF
--- a/lib/clojure-indent.js
+++ b/lib/clojure-indent.js
@@ -2,7 +2,7 @@
 
 const oneIndentForms = ['fn', 'def', 'defn', 'ns', 'let', 'for', 'loop',
   'when', 'when-let', 'if', 'if-let', 'if-not', 'when-not', 'cond', 'do',
-  'doseq', 'dotimes'
+  'doseq', 'dotimes', 'defn-', 'deftest', 'deftest-'
 ]
 
 function calculateIndent ({row, column}, content) {


### PR DESCRIPTION
Just a suggestion based on my usage. These are the few situations where I expect clojure-indent to kick in and it currently does not.