### PR TITLE
Added command to re-indent selected lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Minimal Atom package for indenting Clojure code.
 
 I recommend using it alongside [Parinfer](https://atom.io/packages/parinfer)
 
+## Auto-indenting selected lines
+
+Select a section of code and hit `cmd-i` to reindent the entire block appropriately. This can be helpful for fixing large sections of code that were poorly formatted.
+
 ## Current rules
 *  Indent body of some special forms with 2 spaces (`def`, `if`, `for`...)
 *  Align arguments of function / macro call

--- a/keymaps/clojure-indent.json
+++ b/keymaps/clojure-indent.json
@@ -1,5 +1,6 @@
 {
   "atom-text-editor[data-grammar~=\"clojure\"]": {
-    "enter": "clojure-indent:insert-new-line"
+    "enter": "clojure-indent:insert-new-line",
+    "cmd-i": "clojure-indent:reindent-selected"
   }
 }

--- a/lib/clojure-indent.js
+++ b/lib/clojure-indent.js
@@ -5,7 +5,7 @@ const oneIndentForms = ['fn', 'def', 'defn', 'ns', 'let', 'for', 'loop',
   'doseq', 'dotimes'
 ]
 
-function calculateIndent ({row, column}, content) {
+function calculateIndent (content) {
   let x = 0
   let y = 0
   let openBrackets = []
@@ -40,13 +40,39 @@ function calculateIndent ({row, column}, content) {
     : ''
 }
 
+export function reindentSelected() {
+  const editor = atom.workspace.getActiveTextEditor()
+  const buffer = editor.getBuffer()
+  const selectedRange = editor.getSelectedBufferRange()
+  const startRow = selectedRange.start.row
+
+  var lines = editor.getTextInBufferRange(
+      [[0, 0], [startRow - 1, buffer.lineLengthForRow(startRow - 1)]]
+    )
+    .split('\n')
+
+  for (row = startRow; row <= selectedRange.end.row; row++) {
+    let indent = calculateIndent(lines)
+    let newLine = buffer.lineForRow(row)
+    lines.push(newLine)
+    let rowLen = buffer.lineLengthForRow(row)
+
+    buffer.setTextInRange(
+      [[row, 0], [row, rowLen]],
+      indent + newLine.trim()
+    )
+  }
+}
+
 export function insertNewLine () {
   const editor = atom.workspace.getActiveTextEditor()
   const {row, column} = editor.getCursorBufferPosition()
   const lines = editor.getTextInBufferRange([[0, 0], [row, column]])
     .split('\n')
 
-  const indent = calculateIndent({row, column}, lines)
+  const indent = calculateIndent(lines)
+
+  console.log(editor.getSelectedBufferRange())
 
   editor.getBuffer().setTextInRange(
     editor.getSelectedBufferRange(),

--- a/lib/clojure-indent.js
+++ b/lib/clojure-indent.js
@@ -72,8 +72,6 @@ export function insertNewLine () {
 
   const indent = calculateIndent(lines)
 
-  console.log(editor.getSelectedBufferRange())
-
   editor.getBuffer().setTextInRange(
     editor.getSelectedBufferRange(),
     '\n' + indent

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,13 +1,16 @@
 'use babel'
 
 import { CompositeDisposable } from 'atom'
-import { insertNewLine } from './clojure-indent'
+import { insertNewLine, reindentSelected } from './clojure-indent'
 
 export default {
   activate (state) {
     this.subscriptions = new CompositeDisposable()
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
       'clojure-indent:insert-new-line': () => insertNewLine()
+    }))
+    this.subscriptions.add(atom.commands.add('atom-text-editor', {
+      'clojure-indent:reindent-selected': () => reindentSelected()
     }))
   },
 


### PR DESCRIPTION
Some previous Clojure editors I used had features like this. Basically it is just selecting one or more lines of code and then re-indenting them appropriately.

This is surprisingly helpful when trying to find unmatched delimiters because you just need to the general region where the issue is and see where the style goes crazy.